### PR TITLE
Pin Python requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ You can install these libraries using pip:
 pip install Pillow piexif iptcinfo3
 ```
 
+or used the pinned versions to ensure compatibility:
+
+```console
+pip install -r requirements.txt
+```
 
 # Running the Script
 Before running the script, make sure you have the required files. Place the script in the same directory as the JSON file named `posts.json`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+IPTCInfo3==2.1.4
+piexif==1.1.3
+Pillow==11.3.0


### PR DESCRIPTION
Fixes #17, which arises from nonspecific package requirements. I ran into it because I had an old version of Pillow installed, like the person who reported #17.

I'm flexible on the exact versions, feel free to modify them. These are the most recent ones installed by pip on my system, and I can confirm that the script succeeds on Linux with these versions and the default options.